### PR TITLE
Add proxy for /api/leaderboard to microservice

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -7,10 +7,16 @@ export default defineConfig({
 	plugins: [tailwindcss(), sveltekit()],
 
 	// ✅ DEV SERVER PROXY (NO CORS)
-	// Frontend calls /api/... and /storage/... (same-origin),
-	// Vite forwards them to Laravel running on http://localhost:8080
+	// Frontend calls /api/... and /storage/... (same-origin)
+	// - /api/leaderboard -> LeaderboardMicroservice (3002)
+	// - all other /api -> Laravel (8080)
+	// - /storage -> Laravel (8080)
 	server: {
 		proxy: {
+			'/api/leaderboard': {
+				target: 'http://localhost:3002',
+				changeOrigin: true
+			},
 			'/api': {
 				target: 'http://localhost:8080',
 				changeOrigin: true


### PR DESCRIPTION
Updated Vite dev server proxy configuration to forward /api/leaderboard requests to the LeaderboardMicroservice on port 3002, while other /api and /storage requests continue to be proxied to Laravel on port 8080.